### PR TITLE
减少无效的api访问,添加每日自动启动功能,合并手机端和pc端脚本

### DIFF
--- a/tampermonkey/AutoRewards.user.js
+++ b/tampermonkey/AutoRewards.user.js
@@ -19,11 +19,21 @@
 // @namespace    https://greasyfork.org/zh-CN/scripts/477107
 // ==/UserScript==
 
+//自动判断是否为手机
+var is_phone = /Mobi|Android|iPhone/i.test(navigator.userAgent)
 
 var auto_start = true //搜索计数是否每天自动清零 (是否自动启动,需要手动刷新网页)
-var max_rewards = 40; //重复执行的次数
+
+// 手机端23次可得60分,电脑端33次90分
+var max_rewards
+if(is_phone){
+    max_rewards = 24; //重复执行的次数 
+}else{
+    max_rewards = 34; //重复执行的次数
+}
+
 //每执行4次搜索后插入暂停时间,解决账号被监控不增加积分的问题
-var pause_time = 6; // 暂停时长建议为10分钟（600000毫秒=10分钟）
+var pause_time = 60000; // 暂停时长建议为10分钟（600000毫秒=10分钟）
 var search_words = []; //搜索词
 
 //默认搜索词，热门搜索词请求失败时使用
@@ -192,7 +202,10 @@ async function exec() {
         setTimeout(function () {
             GM_setValue('Cnt', currentSearchCount + 1); // 将计数器加1
             let nowtxt = search_words[currentSearchCount]; // 获取当前搜索词
-            nowtxt = AutoStrTrans(nowtxt); // 对搜索词进行替换
+
+            if(!is_phone){
+                nowtxt = AutoStrTrans(nowtxt); // 如果不是手机端,对搜索词进行替换
+            }
 
             // 检查是否需要暂停
             if ((currentSearchCount + 1) % 5 === 0) {
@@ -211,7 +224,9 @@ async function exec() {
         setTimeout(function () {
             GM_setValue('Cnt', currentSearchCount + 1); // 将计数器加1
             let nowtxt = search_words[currentSearchCount]; // 获取当前搜索词
-            nowtxt = AutoStrTrans(nowtxt); // 对搜索词进行替换
+            if(!is_phone){
+                nowtxt = AutoStrTrans(nowtxt); // 如果不是手机端,对搜索词进行替换
+            }
 
             // 检查是否需要暂停
             if ((currentSearchCount + 1) % 5 === 0) {

--- a/tampermonkey/AutoRewards.user.js
+++ b/tampermonkey/AutoRewards.user.js
@@ -26,9 +26,9 @@ var auto_start = true //搜索计数是否每天自动清零 (是否自动启动
 
 // 手机端23次可得60分,电脑端33次90分
 var max_rewards
-if(is_phone){
+if (is_phone) {
     max_rewards = 24; //重复执行的次数 
-}else{
+} else {
     max_rewards = 34; //重复执行的次数
 }
 
@@ -44,10 +44,26 @@ var default_search_words = ["盛年不重来，一日难再晨", "千里之行�
     "人无远虑，必有近忧", "为中华之崛起而读书", "一日无书，百事荒废", "岂能尽如人意，但求无愧我心", "人生自古谁无死，留取丹心照汗青", "吾生也有涯，而知也无涯", "生于忧患，死于安乐",
     "言必信，行必果", "读书破万卷，下笔如有神", "夫君子之行，静以修身，俭以养德", "老骥伏枥，志在千里", "一日不读书，胸臆无佳想", "王侯将相宁有种乎", "淡泊以明志。宁静而致远,", "卧龙跃马终黄土"]
 //{weibohot}微博热搜榜//{douyinhot}抖音热搜榜/{zhihuhot}知乎热搜榜/{baiduhot}百度热搜榜/{toutiaohot}今日头条热搜榜/
-var keywords_source = ['douyinhot', 'zhihuhot', 'baiduhot', 'toutiaohot'];
-var random_keywords_source = keywords_source[Math.floor(Math.random() * keywords_source.length)]
-var current_source_index = 0; // 当前搜索词来源的索引
+// var keywords_source = ['douyinhot', 'zhihuhot', 'baiduhot', 'toutiaohot'];
+// var random_keywords_source = keywords_source[Math.floor(Math.random() * keywords_source.length)]
 
+// var current_source_index = 0; // 当前搜索词来源的索引
+// 适配了tenapi.cn,api.vvhan.com,api-hot.efefee.cn(https://github.com/imsyy/DailyHotApi)的热词api
+var keywords_source = [
+    { url: "https://api.vvhan.com/api/hotlist/baiduRD", data_parse: (data) => { return data.data.map(item => item.title) } },
+    { url: "https://tenapi.cn/v2/douyinhot", data_parse: (data) => { return data.data.map(item => item.name) } },
+    { url: "https://api-hot.efefee.cn/bilibili", data_parse: (data) => { return data.data.map(item => item.title) } },
+    
+    { url: "https://tenapi.cn/v2/zhihuhot", data_parse: (data) => { return data.data.map(item => item.name) } },
+    { url: "https://api.vvhan.com/api/hotlist/bili", data_parse: (data) => { return data.data.map(item => item.title) } },
+    { url: "https://api-hot.efefee.cn/zhihu", data_parse: (data) => { return data.data.map(item => item.title) } },
+    
+    { url: "https://tenapi.cn/v2/baiduhot", data_parse: (data) => { return data.data.map(item => item.name) } },
+    { url: "https://api.vvhan.com/api/hotlist/zhihuHot", data_parse: (data) => { return data.data.map(item => item.title) } },
+    
+    { url: "https://tenapi.cn/v2/toutiaohot", data_parse: (data) => { return data.data.map(item => item.name) } },
+    { url: "https://api.vvhan.com/api/hotlist/wbHot", data_parse: (data) => { return data.data.map(item => item.title) } },
+]
 
 // 新增每日自动清零计数,不需要手动开始
 function set_run_data(data) {
@@ -61,6 +77,7 @@ var default_run_data = {
     date: "",
     keywords: default_search_words,
     is_fetch_keywords: false,//是否获取关键词标记
+    current_source_index: 0,
 }
 // 
 var run_data = JSON.parse(JSON.stringify(default_run_data))
@@ -74,13 +91,21 @@ else {
 var date = new Date()
 const time_today = "" + date.getFullYear() + (date.getMonth() + 1) + date.getDate()
 if (time_today != run_data.date && auto_start) {
+    // 重置设置,继承前一天的搜索词
     run_data.date = time_today
     run_data.is_fetch_keywords = false
+    run_data.current_source_index = 0
     GM_setValue('Cnt', 0); // 如果是新的一天,并且autostart为true,将计数器重置为0
     set_run_data(run_data)
 }
 
-
+async function sleep(t) {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, t); // 2000 毫秒等于 2 秒
+    });
+}
 /**
  * 尝试从多个搜索词来源获取搜索词，如果所有来源都失败，则返回默认搜索词。
  * @returns {Promise<string[]>} 返回搜索到的name属性值列表或默认搜索词列表
@@ -90,10 +115,11 @@ async function douyinhot_dic() {
     if (run_data.is_fetch_keywords) {
         return run_data.keywords
     }
-    while (current_source_index < keywords_source.length) {
-        const source = keywords_source[current_source_index]; // 获取当前搜索词来源
+
+    while (run_data.current_source_index < keywords_source.length) {
+        const source = keywords_source[run_data.current_source_index]; // 获取当前搜索词来源
         try {
-            const response = await fetch("https://tenapi.cn/v2/" + source); // 发起网络请求
+            const response = await fetch(source.url); // 发起网络请求
             if (!response.ok) {
                 throw new Error('HTTP error! status: ' + response.status); // 如果响应状态不是OK，则抛出错误
             }
@@ -101,14 +127,25 @@ async function douyinhot_dic() {
 
             if (data.data.some(item => item)) {
                 // 如果数据中存在有效项
-                // 提取每个元素的name属性值
-                const names = data.data.map(item => item.name);
+                // 提取返回数据中的元素
+                // const names = data.data.map(item => item.name);
+                console.log("提取返回数据中的元素", data);
+
+                let names = source.data_parse(data);
+
+                // 将昨天的关键词和这次获取的关键词合并,解决部分接口返回关键词数量不够的问题
+                if (names.length < max_rewards) {
+                    let last_keywords = run_data.keywords
+                    last_keywords.length = max_rewards - names.length + 5
+                    names = names.concat(last_keywords)
+                }
+
 
                 // 获取关键词后,将已获取标记设为true,当天内的下次搜索不需要再获取关键词
                 run_data.is_fetch_keywords = true
                 run_data.keywords = names
                 set_run_data(run_data)
-                console.log("run_data:",run_data);
+                console.log("run_data:", run_data);
 
                 return names; // 返回搜索到的name属性值列表
             }
@@ -116,9 +153,9 @@ async function douyinhot_dic() {
             // 当前来源请求失败，记录错误并尝试下一个来源
             console.error('搜索词来源请求失败:', error);
         }
-
+        await sleep(1000)
         // 尝试下一个搜索词来源
-        current_source_index++;
+        run_data.current_source_index++;
     }
 
     // 所有搜索词来源都已尝试且失败
@@ -203,7 +240,7 @@ async function exec() {
             GM_setValue('Cnt', currentSearchCount + 1); // 将计数器加1
             let nowtxt = search_words[currentSearchCount]; // 获取当前搜索词
 
-            if(!is_phone){
+            if (!is_phone) {
                 nowtxt = AutoStrTrans(nowtxt); // 如果不是手机端,对搜索词进行替换
             }
 
@@ -224,7 +261,7 @@ async function exec() {
         setTimeout(function () {
             GM_setValue('Cnt', currentSearchCount + 1); // 将计数器加1
             let nowtxt = search_words[currentSearchCount]; // 获取当前搜索词
-            if(!is_phone){
+            if (!is_phone) {
                 nowtxt = AutoStrTrans(nowtxt); // 如果不是手机端,对搜索词进行替换
             }
 

--- a/tampermonkey/MobileRewards.user.js
+++ b/tampermonkey/MobileRewards.user.js
@@ -71,16 +71,7 @@ async function douyinhot_dic() {
     console.error('所有搜索词来源请求失败');
     return default_search_words; // 返回默认搜索词列表
 }
-// 调用douyinhot_dic函数，获取names列表
-douyinhot_dic()
-    .then(names => {
-        //   console.log(names[0]);
-        search_words = names;
-        exec()
-    })
-    .catch(error => {
-        console.error(error);
-    });
+
 
 // 定义菜单命令：开始
 let menu1 = GM_registerMenuCommand('开始', function () {
@@ -106,7 +97,7 @@ function generateRandomString(length) {
     return result;
 }
 
-function exec() {
+async function exec() {
     // 生成随机延迟时间
     let randomDelay = Math.floor(Math.random() * 20000) + 10000; // 10000 毫秒 = 10 秒
     let randomString = generateRandomString(4); //生成4个长度的随机字符串
@@ -120,7 +111,10 @@ function exec() {
 
     // 获取当前搜索次数
     let currentSearchCount = GM_getValue('Cnt');
-
+    // 如果当前次数小于最大次数,才获取搜索词条
+    if(currentSearchCount <= max_rewards){
+        search_words = await douyinhot_dic()
+    }
     // 根据计数器的值选择搜索引擎
     if (currentSearchCount <= max_rewards / 2) {
         let tt = document.getElementsByTagName("title")[0];
@@ -160,3 +154,7 @@ function exec() {
         }, randomDelay);
     }
 }
+//页面加载完成后3秒再执行,避免部分情况下报错
+setTimeout(()=>{
+    exec()
+},3000)

--- a/tampermonkey/PCRewards.user.js
+++ b/tampermonkey/PCRewards.user.js
@@ -69,15 +69,7 @@ async function douyinhot_dic() {
     console.error('所有搜索词来源请求失败');
     return default_search_words; // 返回默认搜索词列表
 }
-douyinhot_dic()
-    .then(names => {
-        //   console.log(names[0]);
-        search_words = names;
-        exec()
-    })
-    .catch(error => {
-        console.error(error);
-    });
+
 
 // 定义菜单命令：开始
 let menu1 = GM_registerMenuCommand('开始', function () {
@@ -122,7 +114,7 @@ function generateRandomString(length) {
     return result;
 }
 
-function exec() {
+async function exec() {
     // 生成随机延迟时间
     let randomDelay = Math.floor(Math.random() * 20000) + 10000; // 10000 毫秒 = 10 秒
     let randomString = generateRandomString(4); //生成4个长度的随机字符串
@@ -136,7 +128,10 @@ function exec() {
 
     // 获取当前搜索次数
     let currentSearchCount = GM_getValue('Cnt');
-
+    // 如果当前次数小于最大次数,才获取搜索词条
+    if(currentSearchCount <= max_rewards){
+        search_words = await douyinhot_dic()
+    }
     // 根据计数器的值选择搜索引擎
     if (currentSearchCount <= max_rewards / 2) {
         let tt = document.getElementsByTagName("title")[0];
@@ -178,3 +173,7 @@ function exec() {
         }, randomDelay);
     }
 }
+//页面加载完成后3秒再执行,避免部分情况下报错
+setTimeout(()=>{
+    exec()
+},3000)


### PR DESCRIPTION
减少api访问,现在每天只需要访问成功一次api,避免访问失败导致使用默认词的问题
添加每天自动启动功能,auto_start变量为true时,每天会自动重置计数(需要手动刷新网页)
合并pc和手机端,pc端和手机端的区别就是搜索次数和pc端会额外调用AutoStrTrans函数,添加的AutoRewards.user.js文件会自动判断是否为手机端
 